### PR TITLE
Fix MobjThinker hooks performance

### DIFF
--- a/Lua/1_Gameplay/1_Main/chaseritems.lua
+++ b/Lua/1_Gameplay/1_Main/chaseritems.lua
@@ -256,65 +256,61 @@ addHook("MobjSpawn", function(mo)
 	mo.extravalue1 = 69
 end, MT_JAWZ)
 
-addHook("MobjThinker", function(mo)
-	if timetravel.CHASER_VERSION > CHASER_VERSION then return end
-	if not timetravel.isActive then return end
-	local isItemTrackerType = false
-	for i = 1, #types do
-		isItemTrackerType = (types[i] == mo.type)
-		if isItemTrackerType then break end
-	end
-	if not isItemTrackerType then return end
-	if mo.timetravel == nil then mo.timetravel = {} end
-	
-	local itemTarget = mo.tracer
-	
-	local justSpawned = false
-	if mo.timetravel.isTimeWarped == nil then
-		local owner = mo.target
-		if owner then
-			mo.timetravel.isTimeWarped = owner.player.mo.timetravel.isTimeWarped
-		end
-			
-		if mo.type == MT_JAWZ and itemTarget == nil then
-			local ownerPlayer = nil
-			if owner then ownerPlayer = owner.player end
-			
-			if owner and ownerPlayer then
-				local finalJawzTarget = timetravel.K_FindJawzTargetEX(owner, ownerPlayer)
-				if finalJawzTarget then
-					itemTarget = finalJawzTarget.mo
-					mo.tracer = itemTarget
+for _, type in pairs(types) do
+	addHook("MobjThinker", function(mo)
+		if timetravel.CHASER_VERSION > CHASER_VERSION then return end
+		if not timetravel.isActive then return end
+		if mo.timetravel == nil then mo.timetravel = {} end
+		
+		local itemTarget = mo.tracer
+		
+		local justSpawned = false
+		if mo.timetravel.isTimeWarped == nil then
+			local owner = mo.target
+			if owner then
+				mo.timetravel.isTimeWarped = owner.player.mo.timetravel.isTimeWarped
+			end
+				
+			if mo.type == MT_JAWZ and itemTarget == nil then
+				local ownerPlayer = nil
+				if owner then ownerPlayer = owner.player end
+				
+				if owner and ownerPlayer then
+					local finalJawzTarget = timetravel.K_FindJawzTargetEX(owner, ownerPlayer)
+					if finalJawzTarget then
+						itemTarget = finalJawzTarget.mo
+						mo.tracer = itemTarget
+					end
 				end
 			end
+			justSpawned = true
 		end
-		justSpawned = true
-	end
 
-	if justSpawned then return end
-	if mo.type == MT_SPB and mo.threshold ~= 0 then return end
-	-- Chasing!
-	
-	if itemTarget == nil then return end
-	
-	if mo.type == MT_JAWZ then
-		if mo.health > 0 and mo.reticule == nil then
-			local reticule = createPlayerReticule(itemTarget, true)
-			reticule.color = mo.cvmem
-			reticule.extravalue = 1
-			reticule.tracer = mo
-			mo.reticule = reticule
-		elseif mo.health <= 0 and (mo.reticule and mo.reticule.valid) then
-			P_KillMobj(mo.reticule)
-			mo.reticule = nil
+		if justSpawned then return end
+		if mo.type == MT_SPB and mo.threshold ~= 0 then return end
+		-- Chasing!
+		
+		if itemTarget == nil then return end
+		
+		if mo.type == MT_JAWZ then
+			if mo.health > 0 and mo.reticule == nil then
+				local reticule = createPlayerReticule(itemTarget, true)
+				reticule.color = mo.cvmem
+				reticule.extravalue = 1
+				reticule.tracer = mo
+				mo.reticule = reticule
+			elseif mo.health <= 0 and (mo.reticule and mo.reticule.valid) then
+				P_KillMobj(mo.reticule)
+				mo.reticule = nil
+			end
 		end
-	end
-	
-	if mo.timetravel.isTimeWarped ~= itemTarget.timetravel.isTimeWarped then
-		timetravel.changePositions(mo)
-	end
-	
-end)
+		
+		if mo.timetravel.isTimeWarped ~= itemTarget.timetravel.isTimeWarped then
+			timetravel.changePositions(mo)
+		end
+	end, type)
+end
+
 
 local reticuleState = S_PLAYERRETICULE
 addHook("MapChange", function(mapnum)

--- a/Lua/1_Gameplay/1_Main/chaseritems.lua
+++ b/Lua/1_Gameplay/1_Main/chaseritems.lua
@@ -4,7 +4,7 @@ made 15/01/2023 (dd/mm/aaaa).
 ]]
 
 -- You are the Chaser! Bring it!
-local CHASER_VERSION = 11
+local CHASER_VERSION = 12
 
 -- avoid redefiniton on updates
 if timetravel.CHASER_VERSION == nil or timetravel.CHASER_VERSION < CHASER_VERSION then

--- a/Lua/2_Cosmetic/Echoes/echoes.lua
+++ b/Lua/2_Cosmetic/Echoes/echoes.lua
@@ -400,23 +400,32 @@ addHook("PlayerExplode", function(player, inflictor, source)
 	end
 end)
 
+addHook("ThinkFrame", function()
+	if timetravel.ECHOES_VERSION > ECHOES_VERSION then return end
+	if not timetravel.isActive then return end
+	if leveltime < 3 then return end
+
+	for mobj in thinkers.iterate("mobj") do
+		-- Spawn procedure for normal mobjs - it will have an echo if applicable.
+		if mobj.echoable then
+			timetravel.echoes_SpawnHandler(mobj)
+		end
+		if mobj.valid and mobj.linkedItem ~= nil then
+			-- Handle echo-to-nonecho collision stuff here.
+			timetravel.echoes_CollisionHandler(mobj)
+		end
+	end
+end)
+
 addHook("MobjThinker", function(mobj)
 	if timetravel.ECHOES_VERSION > ECHOES_VERSION then return end
 	if not timetravel.isActive then return end
 	if leveltime < 3 then return end
-	
-	if not (mobj and mobj.valid) then return end
 
-	if mobj.type == MT_ECHOGHOST and mobj.linkedItem and mobj.linkedItem.valid then -- Movement thinker for echo ghosts
+	if mobj.linkedItem and mobj.linkedItem.valid then
 		timetravel.echoes_Thinker(mobj)
-	else
-		-- Spawn procedure for other mobjs - a normal mobj will have an echo if applicable.
-		timetravel.echoes_SpawnHandler(mobj)
-		if not (mobj and mobj.valid) then return end
-		-- Handle echo-to-nonecho collision stuff here.
-		timetravel.echoes_CollisionHandler(mobj)
 	end
-end)
+end, MT_ECHOGHOST)
 
 addHook("MobjSpawn", function(mobj)
 	if timetravel.ECHOES_VERSION > ECHOES_VERSION then return end

--- a/Lua/2_Cosmetic/Echoes/echoes.lua
+++ b/Lua/2_Cosmetic/Echoes/echoes.lua
@@ -39,7 +39,6 @@ local GT_MATCH = GT_MATCH
 local S_INVISIBLE = S_INVISIBLE
 
 local table_insert = table.insert
-local pairs = pairs
 local ipairs = ipairs
 local K_SpawnMineExplosion = K_SpawnMineExplosion
 local P_SpawnShadowMobj = P_SpawnShadowMobj
@@ -278,8 +277,9 @@ end
 -- need their echo to run immediately after spawning, in order to register point-blank hits.
 local echoqueue = {}
 timetravel.echoes_SpawnQueuedEchoes = function()
-	for mobj in pairs(echoqueue) do
-		echoqueue[mobj] = nil
+	for i = #echoqueue, 1, -1 do
+		local mobj = echoqueue[i]
+		echoqueue[i] = nil
 		if mobj.valid then timetravel.echoes_SpawnHandler(mobj) end
 	end
 end
@@ -452,7 +452,7 @@ addHook("MobjSpawn", function(mobj)
 	for _, value in ipairs(timetravel.validTypesToEcho) do
 		if value == mobj.type then
 			mobj.echoable = true
-			echoqueue[mobj] = true
+			table.insert(echoqueue, mobj)
 			break
 		end
 	end


### PR DESCRIPTION
I recently discovered that Time Travel adds two global MobjThinker hooks, which run on every mobj type in the game. That doesn't exactly bode well for maps with 4000+ mobjs! So let's fix this:

1. Add separate hooks for the Jawz and SPB.
2. Replace the echoes MobjThinker hook with a ThinkFrame (+ thinkers.iterate) hook.

This fixes major slowdown on maps like Ironbed Descent.
Before:
![Screenshot_2024-02-03_12-12-51](https://github.com/JugadorXEI/time-travel/assets/86008856/f665976b-b306-42a8-8591-c8b44111baa6)
After:
![Screenshot_2024-02-03_12-13-25](https://github.com/JugadorXEI/time-travel/assets/86008856/022e42ff-8bd5-44d2-a057-ecdef034fe71)

Besides that, there's also some small performance improvements:
* Give echo ghosts their own MobjThinker hook. Saves a whole lot of fastcmps per mobj in the main hook.
* Add early-reject checks to the main hook. Kind of a hack, but calls in Lua ain't cheap!
* Remove some now-unnecessary validity checks.

EDIT: better screenshots