### PR TITLE
Fix echoqueue leaking

### DIFF
--- a/Lua/2_Cosmetic/Echoes/echoes.lua
+++ b/Lua/2_Cosmetic/Echoes/echoes.lua
@@ -1,4 +1,4 @@
-local ECHOES_VERSION = 13
+local ECHOES_VERSION = 14
 
 -- avoid redefiniton on updates
 if timetravel.ECHOES_VERSION == nil or timetravel.ECHOES_VERSION < ECHOES_VERSION then
@@ -448,6 +448,7 @@ end, MT_ECHOGHOST)
 
 addHook("MobjSpawn", function(mobj)
 	if timetravel.ECHOES_VERSION > ECHOES_VERSION then return end
+	if not timetravel.isActive then return end
 	-- Check if this is a echoes-able mobj.
 	for _, value in ipairs(timetravel.validTypesToEcho) do
 		if value == mobj.type then


### PR DESCRIPTION
I forgot to add an isActive check to the MobjSpawn hook, which means the echoqueue table grows endlessly once you leave a time travel map. Oops 😶 